### PR TITLE
Print colored text for "ok", "skipped", and "FAILED"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,7 @@ version = "0.1.11"
 dependencies = [
  "abscissa_core",
  "cargo-audit",
+ "colored",
  "include_dir",
  "structopt",
  "test-case",
@@ -229,6 +230,17 @@ dependencies = [
  "atty",
  "backtrace",
  "termcolor",
+]
+
+[[package]]
+name = "colored"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
+dependencies = [
+ "atty",
+ "lazy_static",
+ "winapi",
 ]
 
 [[package]]
@@ -998,9 +1010,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ structopt = "0.3.21"
 abscissa_core = "0.5.2"
 cargo-audit = "0.14.1"
 include_dir = "0.7.2"
+colored = "2.0.0"
 
 [dev-dependencies]
 test-case = "1.0.0"

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -4,6 +4,7 @@ use std::io::Result;
 use std::path::PathBuf;
 
 mod phaseresult;
+use colored::Colorize;
 use phaseresult::PhaseResult;
 
 pub struct Runner {
@@ -59,13 +60,13 @@ impl Runner {
 
         let results = if output.status.success() {
             if output.stdout.starts_with(b"skipped:\n") {
-                println!("skipped.");
+                println!("{}.", "skipped".green());
             } else {
-                println!("ok.");
+                println!("{}.", "ok".green());
             }
             &mut self.passes
         } else {
-            println!("FAILED.");
+            println!("{}.", "FAILED".red());
             &mut self.fails
         };
 
@@ -79,7 +80,7 @@ impl Runner {
         let failcount = self.fails.len();
 
         let (exitstatus, label) = if failcount == 0 {
-            (0, "ok")
+            (0, "ok".green())
         } else {
             println!("\nfailures:\n");
 
@@ -87,7 +88,7 @@ impl Runner {
                 fres.display()?;
             }
 
-            (1, "FAILED")
+            (1, "FAILED".red())
         };
 
         println!(


### PR DESCRIPTION
Before:
<img width="1605" alt="Before" src="https://user-images.githubusercontent.com/25121520/168492418-5f1c5806-254e-4404-a68b-c5dd6bb43ef6.png">

After:
<img width="1605" alt="After" src="https://user-images.githubusercontent.com/25121520/168492421-26a3cb51-9553-4f6c-beca-713939cb60e1.png">

This adds the [colored](https://crates.io/crates/colored) crate as a dependency.