### PR TITLE
Release 0.1.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,7 +176,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-checkmate"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "abscissa_core",
  "cargo-audit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-checkmate"
-version = "0.1.12"
+version = "0.1.13"
 authors = ["nathan <nathan+dev@electriccoin.co>"]
 edition = "2018"
 description = "checkmate checks all the things - comprehensive out-of-the-box safety & hygiene checks."

--- a/util/make-release.sh
+++ b/util/make-release.sh
@@ -8,7 +8,7 @@ WORKDIR=''
 
 function main
 {
-  [ $# = 1 ] || fail "Wrong number of arguments. Expected: $SCRIPT <new version>" 
+  [ $# = 1 ] || fail "Wrong number of arguments. Expected: $SCRIPT <new version>"
   local newver="$1"
 
   init-workdir
@@ -20,7 +20,7 @@ function main
 
   vrun git add "$REPODIR"/Cargo.{toml,lock}
   vrun git commit -m "New Release: $newver"
-  vrun git tag --sign -m "Release $newver" "$newver"
+  vrun git tag "v${newver}"
   vrun git log -1
 }
 


### PR DESCRIPTION
This release fixes a regression in `cargo hook install github-ci`, and also removes orphaned `.rs` files.