### PR TITLE
Use clap documented api

### DIFF
--- a/src/hook.rs
+++ b/src/hook.rs
@@ -4,7 +4,7 @@ mod githubci;
 use crate::executable::Executable;
 use crate::srcbundle::SourceBundle;
 use crate::IOResult;
-use clap::{StructOpt, Subcommand};
+use clap::{Parser, Subcommand};
 
 /// manage repository hooks.
 #[derive(Debug, Subcommand)]
@@ -16,7 +16,7 @@ pub enum Hook {
 }
 
 /// hook type option
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub struct HookTypeOption {
     /// Force modifying the hook even if the contents are unrecognized
     #[structopt(long)]
@@ -28,7 +28,7 @@ pub struct HookTypeOption {
 }
 
 /// hook type
-#[derive(Debug, Default, StructOpt)]
+#[derive(Debug, Default, Parser)]
 pub enum HookType {
     /// all hooks
     #[default]

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -18,11 +18,11 @@ pub enum Hook {
 #[derive(Debug, clap::Parser)]
 pub struct HookTypeOption {
     /// Force modifying the hook even if the contents are unrecognized
-    #[structopt(long)]
+    #[clap(long)]
     force: bool,
 
     /// Hook type: all, git, or github-ci
-    #[structopt(default_value_t)]
+    #[clap(default_value_t)]
     hook_type: HookType,
 }
 
@@ -74,7 +74,7 @@ impl HookType {
     }
 }
 
-// TODO: structopt/clap already knows how to format these, can we reuse that?
+// TODO: clap already knows how to format these, can we reuse that?
 impl std::fmt::Display for HookType {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         use HookType::*;
@@ -91,7 +91,7 @@ impl std::fmt::Display for HookType {
     }
 }
 
-// TODO: structopt/clap already knows how to format these, can we reuse that?
+// TODO: clap already knows how to format these, can we reuse that?
 impl std::str::FromStr for HookType {
     type Err = String;
 

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -4,10 +4,9 @@ mod githubci;
 use crate::executable::Executable;
 use crate::srcbundle::SourceBundle;
 use crate::IOResult;
-use clap::{Parser, Subcommand};
 
 /// manage repository hooks.
-#[derive(Debug, Subcommand)]
+#[derive(Debug, clap::Subcommand)]
 pub enum Hook {
     /// install repository hooks
     Install(HookTypeOption),
@@ -16,7 +15,7 @@ pub enum Hook {
 }
 
 /// hook type option
-#[derive(Debug, Parser)]
+#[derive(Debug, clap::Parser)]
 pub struct HookTypeOption {
     /// Force modifying the hook even if the contents are unrecognized
     #[structopt(long)]
@@ -28,7 +27,7 @@ pub struct HookTypeOption {
 }
 
 /// hook type
-#[derive(Debug, Default, Parser)]
+#[derive(Debug, Default, clap::Parser)]
 pub enum HookType {
     /// all hooks
     #[default]

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -79,15 +79,12 @@ impl std::fmt::Display for HookType {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         use HookType::*;
 
-        write!(
-            f,
-            "{}",
-            match self {
-                All => "all",
-                Git => "git",
-                GithubCI => "github-ci",
-            }
-        )
+        match self {
+            All => "all",
+            Git => "git",
+            GithubCI => "github-ci",
+        }
+        .fmt(f)
     }
 }
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -5,12 +5,12 @@ use crate::readme::Readme;
 use crate::IOResult;
 
 #[derive(Debug, clap::Parser)]
-#[structopt(
+#[clap(
     setting = clap::AppSettings::NoBinaryName,
     about = env!("CARGO_PKG_DESCRIPTION"),
 )]
 pub struct Options {
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     cmd: Option<Subcommand>,
 }
 
@@ -19,10 +19,10 @@ pub enum Subcommand {
     /// Run all phases.
     Everything,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     Phase(Phase),
 
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     Hook(Hook),
     Readme(Readme),
 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -3,12 +3,10 @@ use crate::hook::Hook;
 use crate::phase::Phase;
 use crate::readme::Readme;
 use crate::IOResult;
-use clap::AppSettings;
-use clap::Parser;
 
-#[derive(Debug, Parser)]
+#[derive(Debug, clap::Parser)]
 #[structopt(
-    setting = AppSettings::NoBinaryName,
+    setting = clap::AppSettings::NoBinaryName,
     about = env!("CARGO_PKG_DESCRIPTION"),
 )]
 pub struct Options {
@@ -16,7 +14,7 @@ pub struct Options {
     cmd: Option<Subcommand>,
 }
 
-#[derive(Debug, Parser)]
+#[derive(Debug, clap::Parser)]
 pub enum Subcommand {
     /// Run all phases.
     Everything,
@@ -42,11 +40,15 @@ impl Options {
             it.next();
         }
 
-        Self::from_clap(
-            &Self::clap()
-                .bin_name("cargo-checkmate")
-                .get_matches_from(it),
-        )
+        {
+            use clap::Parser;
+
+            Self::from_clap(
+                &Self::clap()
+                    .bin_name("cargo-checkmate")
+                    .get_matches_from(it),
+            )
+        }
     }
 }
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -4,9 +4,9 @@ use crate::phase::Phase;
 use crate::readme::Readme;
 use crate::IOResult;
 use clap::AppSettings;
-use clap::StructOpt;
+use clap::Parser;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 #[structopt(
     setting = AppSettings::NoBinaryName,
     about = env!("CARGO_PKG_DESCRIPTION"),
@@ -16,7 +16,7 @@ pub struct Options {
     cmd: Option<Subcommand>,
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub enum Subcommand {
     /// Run all phases.
     Everything,

--- a/src/phase.rs
+++ b/src/phase.rs
@@ -1,9 +1,9 @@
 use crate::executable::Executable;
 use crate::IOResult;
-use clap::StructOpt;
+use clap::Parser;
 use std::fmt;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub enum Phase {
     /// phase: `cargo check` syntax + type checking.
     Check,
@@ -27,7 +27,7 @@ pub enum Phase {
     Audit(AuditOptions),
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub struct AuditOptions {
     #[structopt(short, long, help = "Force an audit check.")]
     force: bool,

--- a/src/phase.rs
+++ b/src/phase.rs
@@ -28,7 +28,7 @@ pub enum Phase {
 
 #[derive(Debug, clap::Parser)]
 pub struct AuditOptions {
-    #[structopt(short, long, help = "Force an audit check.")]
+    #[clap(short, long, help = "Force an audit check.")]
     force: bool,
 }
 

--- a/src/phase.rs
+++ b/src/phase.rs
@@ -1,9 +1,8 @@
 use crate::executable::Executable;
 use crate::IOResult;
-use clap::Parser;
 use std::fmt;
 
-#[derive(Debug, Parser)]
+#[derive(Debug, clap::Parser)]
 pub enum Phase {
     /// phase: `cargo check` syntax + type checking.
     Check,
@@ -27,7 +26,7 @@ pub enum Phase {
     Audit(AuditOptions),
 }
 
-#[derive(Debug, Parser)]
+#[derive(Debug, clap::Parser)]
 pub struct AuditOptions {
     #[structopt(short, long, help = "Force an audit check.")]
     force: bool,

--- a/src/readme.rs
+++ b/src/readme.rs
@@ -1,10 +1,9 @@
 use crate::executable::Executable;
 use crate::IOResult;
-use clap::Parser;
 
 const README: &str = include_str!("../README.md");
 
-#[derive(Debug, Parser)]
+#[derive(Debug, clap::Parser)]
 /// Display the project README.md
 pub struct Readme {}
 

--- a/src/readme.rs
+++ b/src/readme.rs
@@ -1,10 +1,10 @@
 use crate::executable::Executable;
 use crate::IOResult;
-use clap::StructOpt;
+use clap::Parser;
 
 const README: &str = include_str!("../README.md");
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 /// Display the project README.md
 pub struct Readme {}
 


### PR DESCRIPTION
This cleans up vestigial uses of `structopt`. `clap` provides doc-hidden aliases to support migration, and we update all uses to the publicly documented `clap` API.