### PR TITLE
License badge and url cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["nathan <nathan+dev@electriccoin.co>"]
 edition = "2018"
 description = "checkmate checks all the things - comprehensive out-of-the-box safety & hygiene checks."
 license = "MIT"
-homepage = "https://github.com/nathan-at-least/cargo-checkmate"
+homepage = "https://github.com/cargo-checkmate/cargo-checkmate"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # cargo-checkmate
-[![CICD](https://github.com/nathan-at-least/cargo-checkmate/actions/workflows/cargo-checkmate.yaml/badge.svg)](https://github.com/nathan-at-least/cargo-checkmate/actions/workflows/cargo-checkmate.yaml/badge.svg)
+[![CICD](https://github.com/cargo-checkmate/cargo-checkmate/actions/workflows/cargo-checkmate.yaml/badge.svg)](https://github.com/cargo-checkmate/cargo-checkmate/actions/workflows/cargo-checkmate.yaml/badge.svg)
 ![Crates.io](https://img.shields.io/crates/v/cargo-checkmate)
-![Stars](https://img.shields.io/github/stars/nathan-at-least/cargo-checkmate)
+![Stars](https://img.shields.io/github/stars/cargo-checkmate/cargo-checkmate)
 
 Perform a series of useful checks out of the box. `cargo-checkmate` ensures your project builds, tests pass, has good format, doesn't have dependencies with known vulnerabilities, and so on.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 [![CICD](https://github.com/nathan-at-least/cargo-checkmate/actions/workflows/cargo-checkmate.yaml/badge.svg)](https://github.com/nathan-at-least/cargo-checkmate/actions/workflows/cargo-checkmate.yaml/badge.svg)
 ![Crates.io](https://img.shields.io/crates/v/cargo-checkmate)
 ![Stars](https://img.shields.io/github/stars/nathan-at-least/cargo-checkmate)
-![License](https://img.shields.io/github/license/nathan-at-least/cargo-checkmate)
 
 Perform a series of useful checks out of the box. `cargo-checkmate` ensures your project builds, tests pass, has good format, doesn't have dependencies with known vulnerabilities, and so on.
 


### PR DESCRIPTION
This removes the Github license badge; see #18 which is blocked on github and crates.io synchronizing their metadata usage. We prioritize crates.io over github because we assume the primary consumers come through the rust ecosystem (`cargo install`, `cargo search`, https://crates.io, and https://docs.rs).