### PR TITLE
Switch to caller/callee actions.

### DIFF
--- a/.github/workflows/callee.yaml
+++ b/.github/workflows/callee.yaml
@@ -1,0 +1,80 @@
+name: cargo-checkmate phases
+
+on:
+  workflow_call:
+    inputs:
+      checkmate-version:
+        type: string
+        default: "^0.1.14"
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: baptiste0928/cargo-install@v2
+        with:
+          crate: cargo-checkmate
+          version: ${{ inputs.checkmate-version }}
+      - run: cargo-checkmate audit
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: baptiste0928/cargo-install@v2
+        with:
+          crate: cargo-checkmate
+          version: ${{ inputs.checkmate-version }}
+      - run: cargo-checkmate build
+
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: baptiste0928/cargo-install@v2
+        with:
+          crate: cargo-checkmate
+          version: ${{ inputs.checkmate-version }}
+      - run: cargo-checkmate check
+
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: baptiste0928/cargo-install@v2
+        with:
+          crate: cargo-checkmate
+          version: ${{ inputs.checkmate-version }}
+      - run: cargo-checkmate clippy
+
+  doc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: baptiste0928/cargo-install@v2
+        with:
+          crate: cargo-checkmate
+          version: ${{ inputs.checkmate-version }}
+      - run: cargo-checkmate doc
+
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: baptiste0928/cargo-install@v2
+        with:
+          crate: cargo-checkmate
+          version: ${{ inputs.checkmate-version }}
+      - run: cargo-checkmate format
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: baptiste0928/cargo-install@v2
+        with:
+          crate: cargo-checkmate
+          version: ${{ inputs.checkmate-version }}
+      - run: cargo-checkmate test
+

--- a/.github/workflows/cargo-checkmate.yaml
+++ b/.github/workflows/cargo-checkmate.yaml
@@ -1,17 +1,9 @@
-on: [push, pull_request]
-
 name: cargo-checkmate Continuous Integration
 
+on:
+  pull_request:
+    types: [opened, synchronize]
+
 jobs:
-  cargo-checkmate:
-    name: cargo-checkmate
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - run: cargo install cargo-checkmate
-      - run: cargo-checkmate
+  phases:
+    uses: ./.github/workflows/callee.yaml


### PR DESCRIPTION
Split the merge-acceptance action into caller and callee. Future github CI hooks will delegate to the callee here.

This callee does cached install of `cargo-checkmate` and runs each phase as a separate job.