### PR TITLE
Unflattened phase args into an explicit `run` subcommand.

### DIFF
--- a/src/githook.rs
+++ b/src/githook.rs
@@ -48,12 +48,12 @@ pub fn uninstall() -> anyhow::Result<()> {
 }
 
 pub fn run() -> anyhow::Result<()> {
-    use crate::options::Subcommand::Everything;
+    use crate::phase::Phase;
 
     println!("cargo checkmate git-hook:");
 
     // TODO: Ensure the repo is clean first.
-    Everything.execute()
+    Phase::execute_everything()
 }
 
 pub fn print_path() -> anyhow::Result<()> {

--- a/src/options.rs
+++ b/src/options.rs
@@ -64,8 +64,7 @@ impl Executable for Options {
 impl Executable for Subcommand {
     fn execute(&self) -> anyhow::Result<()> {
         match self {
-            Subcommand::Run { phase: None } => Phase::execute_everything(),
-            Subcommand::Run { phase: Some(x) } => x.execute(),
+            Subcommand::Run { phase: x } => x.execute(),
             Subcommand::GitHook(x) => x.execute(),
             Subcommand::Gh(x) => x.execute(),
             Subcommand::Readme(x) => x.execute(),

--- a/src/options.rs
+++ b/src/options.rs
@@ -19,12 +19,13 @@ pub struct Options {
 
 #[derive(Debug, PartialEq, Eq, clap::Parser)]
 pub enum Subcommand {
-    /// Run all phases.
-    Everything,
-
-    #[clap(flatten)]
-    Phase(Phase),
-
+    /// Run validations
+    ///
+    /// If no validation is provided, all are run.
+    Run {
+        #[clap(subcommand)]
+        phase: Option<Phase>,
+    },
     #[clap(subcommand)]
     GitHook(GitHook),
     #[clap(subcommand)]
@@ -55,7 +56,7 @@ impl Options {
 
 impl Executable for Options {
     fn execute(&self) -> anyhow::Result<()> {
-        let default = Subcommand::Everything;
+        let default = Subcommand::Run { phase: None };
         self.cmd.as_ref().unwrap_or(&default).execute()
     }
 }
@@ -63,8 +64,8 @@ impl Executable for Options {
 impl Executable for Subcommand {
     fn execute(&self) -> anyhow::Result<()> {
         match self {
-            Subcommand::Everything => Phase::execute_everything(),
-            Subcommand::Phase(x) => x.execute(),
+            Subcommand::Run { phase: None } => Phase::execute_everything(),
+            Subcommand::Run { phase: Some(x) } => x.execute(),
             Subcommand::GitHook(x) => x.execute(),
             Subcommand::Gh(x) => x.execute(),
             Subcommand::Readme(x) => x.execute(),

--- a/src/options/tests.rs
+++ b/src/options/tests.rs
@@ -1,36 +1,47 @@
-use super::{Options, Subcommand::Phase};
+use super::{Options, Subcommand::Run};
 use crate::phase::Phase::Clippy;
 use test_case::test_case;
 
+const RUN_CLIPPY: Options = Options {
+    cmd: Some(Run {
+        phase: Some(Clippy),
+    }),
+};
+
 #[test_case(
     &["cargo-checkmate"]
-    => Ok(Options { cmd: None})
+    => Ok(Options { cmd: None })
     ; "checkmate-exec-no-args"
 )]
 #[test_case(
     &["cargo", "checkmate"]
-    => Ok(Options { cmd: None})
+    => Ok(Options { cmd: None })
     ; "cargo-checkmate-no-args"
 )]
 #[test_case(
-    &["cargo-checkmate", "clippy"]
-    => Ok(Options { cmd: Some(Phase(Clippy))})
+    &["cargo", "checkmate", "run"]
+    => Ok(Options { cmd: Some(Run { phase: None })})
+    ; "cargo-checkmate-run"
+)]
+#[test_case(
+    &["cargo-checkmate", "run", "clippy"]
+    => Ok(RUN_CLIPPY)
     ; "checkmate-clippy"
 )]
 #[test_case(
-    &["cargo", "checkmate", "clippy"]
-    => Ok(Options { cmd: Some(Phase(Clippy))})
+    &["cargo", "checkmate", "run", "clippy"]
+    => Ok(RUN_CLIPPY)
     ; "cargo-checkmate-clippy"
 )]
 #[test_case(
-    &["/path/to/cargo", "checkmate", "clippy"]
-    => Ok(Options { cmd: Some(Phase(Clippy))})
+    &["/path/to/cargo", "checkmate", "run", "clippy"]
+    => Ok(RUN_CLIPPY)
     ; "cargopath-checkmate-clippy"
 )]
 // This case should not occur in the wild, but will still parse:
 #[test_case(
-    &["cargo", "../foo/weird/checkmate", "clippy"]
-    => Ok(Options { cmd: Some(Phase(Clippy))})
+    &["cargo", "../foo/weird/checkmate", "run", "clippy"]
+    => Ok(RUN_CLIPPY)
     ; "cargo-checkmateweirdpath-clippy"
 )]
 #[test_case(

--- a/src/phase.rs
+++ b/src/phase.rs
@@ -53,6 +53,16 @@ impl Phase {
     }
 }
 
+impl Executable for Option<Phase> {
+    fn execute(&self) -> anyhow::Result<()> {
+        if let Some(phase) = self {
+            phase.execute()
+        } else {
+            Phase::execute_everything()
+        }
+    }
+}
+
 impl Executable for Phase {
     fn execute(&self) -> anyhow::Result<()> {
         use crate::subcommands::{audit, cargo_builtin};

--- a/src/phase.rs
+++ b/src/phase.rs
@@ -4,25 +4,19 @@ use std::fmt;
 
 #[derive(Debug, PartialEq, Eq, clap::Parser)]
 pub enum Phase {
-    /// phase: `cargo check` syntax + type checking.
+    /// `cargo check` syntax + type checking.
     Check,
-
-    /// phase: Use `cargo fmt` to check if code is correctly formatted.
+    /// Use `cargo fmt` to check if code is correctly formatted.
     Format,
-
-    /// phase: `cargo build` the default target.
+    /// `cargo build` the default target.
     Build,
-
-    /// phase: `cargo test` automated unit tests.
+    /// `cargo test` automated unit tests.
     Test,
-
-    /// phase: `cargo doc` generation.
+    /// `cargo doc` generation.
     Doc,
-
-    /// phase: `cargo clippy` lint checks.
+    /// `cargo clippy` lint checks.
     Clippy,
-
-    /// phase: `cargo audit` security advisories across all dependencies.
+    /// `cargo audit` security advisories across all dependencies.
     Audit(AuditOptions),
 }
 

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -39,14 +39,17 @@ impl Runner {
         let phasename = &phase.to_string();
         let exec = std::env::current_exe()?;
 
-        print!("{} {}... ", CMDNAME, phasename);
+        print!("{} run {}... ", CMDNAME, phasename);
 
         {
             use std::io::Write;
             std::io::stdout().flush()?;
         }
 
-        let output = Command::new(exec).arg(phasename).output_anyhow()?;
+        let output = Command::new(exec)
+            .arg("run")
+            .arg(phasename)
+            .output_anyhow()?;
 
         let reloutlog = self.rellog_path(phasename, "stdout");
         let relerrlog = self.rellog_path(phasename, "stderr");

--- a/src/subcommands.rs
+++ b/src/subcommands.rs
@@ -55,6 +55,7 @@ fn audit_if_necessary() -> anyhow::Result<()> {
     if expired || stale {
         let exe = std::env::current_exe()?;
         let status = Command::new(exe)
+            .arg("run")
             .arg("audit")
             .arg("--force")
             .status_anyhow()?;


### PR DESCRIPTION
This change helps distinguish validation phases from other subcommands.