### PR TITLE
Create a flake and update test `help_outside_crate_path` to find binary in any location.

### DIFF
--- a/crates.nix
+++ b/crates.nix
@@ -1,0 +1,16 @@
+{...}: {
+  perSystem = {
+    pkgs,
+    config,
+    ...
+  }: let
+    # TODO: change this to your crate's name
+    crateName = "cargo-checkmate";
+  in {
+    # declare projects
+    # TODO: change this to your crate's path
+    nci.projects.${crateName}.path = ./.;
+    # configure crates
+    nci.crates.${crateName} = {};
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,251 @@
+{
+  "nodes": {
+    "crane": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1699217310,
+        "narHash": "sha256-xpW3VFUG7yE6UE6Wl0dhqencuENSkV7qpnpe9I8VbPw=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "d535642bbe6f377077f7c23f0febb78b1463f449",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "ref": "v0.15.0",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "dream2nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nci",
+          "nixpkgs"
+        ],
+        "purescript-overlay": "purescript-overlay",
+        "pyproject-nix": "pyproject-nix"
+      },
+      "locked": {
+        "lastModified": 1700448730,
+        "narHash": "sha256-5dQTWQgCY1/XXDgxuYP1bT5S6rNdoukFRRmGdaL8uBw=",
+        "owner": "nix-community",
+        "repo": "dream2nix",
+        "rev": "427b5e94f4b57d35466c37bc962eb9122e6df2ad",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "dream2nix",
+        "type": "github"
+      }
+    },
+    "mk-naked-shell": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1681286841,
+        "narHash": "sha256-3XlJrwlR0nBiREnuogoa5i1b4+w/XPe0z8bbrJASw0g=",
+        "owner": "yusdacra",
+        "repo": "mk-naked-shell",
+        "rev": "7612f828dd6f22b7fb332cc69440e839d7ffe6bd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "yusdacra",
+        "repo": "mk-naked-shell",
+        "type": "github"
+      }
+    },
+    "nci": {
+      "inputs": {
+        "crane": "crane",
+        "dream2nix": "dream2nix",
+        "mk-naked-shell": "mk-naked-shell",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "parts": "parts",
+        "rust-overlay": "rust-overlay",
+        "treefmt": "treefmt"
+      },
+      "locked": {
+        "lastModified": 1701497448,
+        "narHash": "sha256-dpxvFEvoh1zOwQtuUUYM9NYUWtsDIGhHTZbiUbVHT4U=",
+        "owner": "yusdacra",
+        "repo": "nix-cargo-integration",
+        "rev": "1838cbe09a9cc61b9d63b851748d510287c67618",
+        "type": "github"
+      },
+      "original": {
+        "owner": "yusdacra",
+        "repo": "nix-cargo-integration",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1701253981,
+        "narHash": "sha256-ztaDIyZ7HrTAfEEUt9AtTDNoCYxUdSd6NrRHaYOIxtk=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "e92039b55bcd58469325ded85d4f58dd5a4eaf58",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nci",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1701473968,
+        "narHash": "sha256-YcVE5emp1qQ8ieHUnxt1wCZCC3ZfAS+SRRWZ2TMda7E=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "34fed993f1674c8d06d58b37ce1e0fe5eebcb9f5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "parts_2": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1701473968,
+        "narHash": "sha256-YcVE5emp1qQ8ieHUnxt1wCZCC3ZfAS+SRRWZ2TMda7E=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "34fed993f1674c8d06d58b37ce1e0fe5eebcb9f5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "purescript-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nci",
+          "dream2nix",
+          "nixpkgs"
+        ],
+        "slimlock": "slimlock"
+      },
+      "locked": {
+        "lastModified": 1696022621,
+        "narHash": "sha256-eMjFmsj2G1E0Q5XiibUNgFjTiSz0GxIeSSzzVdoN730=",
+        "owner": "thomashoneyman",
+        "repo": "purescript-overlay",
+        "rev": "047c7933abd6da8aa239904422e22d190ce55ead",
+        "type": "github"
+      },
+      "original": {
+        "owner": "thomashoneyman",
+        "repo": "purescript-overlay",
+        "type": "github"
+      }
+    },
+    "pyproject-nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1699067645,
+        "narHash": "sha256-SJOEPVFARVfS0qQQqbnGywt8uOZMmlV1PazQtGNNCfQ=",
+        "owner": "adisbladis",
+        "repo": "pyproject.nix",
+        "rev": "56b5a6ae1ac63a0a3a044d602a3b5d09a5d10dc0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "adisbladis",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nci": "nci",
+        "nixpkgs": "nixpkgs",
+        "parts": "parts_2"
+      }
+    },
+    "rust-overlay": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1701483183,
+        "narHash": "sha256-MDH3oUajqTaYClCiq1QK7jWVMtMFDJWxVBCFAnkt6J4=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "47fe4578cb64a365f400e682a70e054657c42fa5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "slimlock": {
+      "inputs": {
+        "nixpkgs": [
+          "nci",
+          "dream2nix",
+          "purescript-overlay",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1688610262,
+        "narHash": "sha256-Wg0ViDotFWGWqKIQzyYCgayeH8s4U1OZcTiWTQYdAp4=",
+        "owner": "thomashoneyman",
+        "repo": "slimlock",
+        "rev": "b5c6cdcaf636ebbebd0a1f32520929394493f1a6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "thomashoneyman",
+        "repo": "slimlock",
+        "type": "github"
+      }
+    },
+    "treefmt": {
+      "inputs": {
+        "nixpkgs": [
+          "nci",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1699786194,
+        "narHash": "sha256-3h3EH1FXQkIeAuzaWB+nK0XK54uSD46pp+dMD3gAcB4=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "e82f32aa7f06bbbd56d7b12186d555223dc399d1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,34 @@
+{
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+  inputs.nci.url = "github:yusdacra/nix-cargo-integration";
+  inputs.nci.inputs.nixpkgs.follows = "nixpkgs";
+  inputs.parts.url = "github:hercules-ci/flake-parts";
+  inputs.parts.inputs.nixpkgs-lib.follows = "nixpkgs";
+
+  outputs = inputs @ {
+    parts,
+    nci,
+    ...
+  }:
+    parts.lib.mkFlake {inherit inputs;} {
+      systems = ["x86_64-linux"];
+      imports = [
+        nci.flakeModule
+        ./crates.nix
+      ];
+      perSystem = {
+        pkgs,
+        config,
+        ...
+      }: let
+        # shorthand for accessing this crate's outputs
+        # you can access crate outputs under `config.nci.outputs.<crate name>` (see documentation)
+        crateOutputs = config.nci.outputs."cargo-checkmate";
+      in {
+        # export the crate devshell as the default devshell
+        devShells.default = crateOutputs.devShell;
+        # export the release package of the crate as default package
+        packages.default = crateOutputs.packages.release;
+      };
+    };
+}

--- a/src/run/tests.rs
+++ b/src/run/tests.rs
@@ -1,35 +1,58 @@
 use anyhow_std::PathAnyhow;
 use std::ffi::OsStr;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 #[test]
 fn help_outside_of_crate_path() -> anyhow::Result<()> {
-    run("cargo", "build")?;
-    let exe = Path::new("target")
-        .join("debug")
-        .join(env!("CARGO_PKG_NAME"))
-        .canonicalize_anyhow()?;
+    run("cargo", &["build", "-v"])?;
 
+    let exe = find_executable()?;
     let td = tempfile::TempDir::new()?;
     td.as_ref().set_to_current_dir_anyhow()?;
 
-    run(exe, "--help")
+    run(exe, &["--help"])
 }
 
-fn run<T>(exe: T, arg: &str) -> anyhow::Result<()>
+fn run<T>(exe: T, args: &[&str]) -> anyhow::Result<()>
 where
     T: AsRef<OsStr>,
 {
-    use std::process::{Command, Stdio};
+    use std::process::Command;
 
     let mut cmd = Command::new(exe);
-    cmd.arg(arg);
-    cmd.stdout(Stdio::null());
-    println!("running: {:?}", &cmd);
+    cmd.args(args);
+    // cmd.stdout(std::process::Stdio::null());
+    eprintln!("running: {:?}", &cmd);
     let status = cmd.status()?;
     if status.success() {
         Ok(())
     } else {
         anyhow::bail!("exit: {status:?}");
     }
+}
+
+fn find_executable() -> anyhow::Result<PathBuf> {
+    try_find_executable("target")?.map(Ok).unwrap_or_else(|| Err(anyhow::anyhow!("could not find executable".to_string())))
+}
+
+fn try_find_executable<P>(dir: P) -> anyhow::Result<Option<PathBuf>>
+where P: AsRef<Path>,
+{
+    for dirres in dir.as_ref().read_dir_anyhow()? {
+        let dirent = dirres?;
+        let md = dirent.metadata()?;
+        let childpath = dirent.path();
+        if md.is_dir() {
+            if let Some(p) = try_find_executable(&childpath)? {
+                return Ok(Some(p));
+            }
+        } else if md.is_file() {
+            use anyhow_std::OsStrAnyhow;
+
+            if childpath.file_name_anyhow()?.to_str_anyhow()? == env!("CARGO_PKG_NAME") {
+                return Ok(Some(childpath.canonicalize_anyhow()?));
+            }
+        }
+    }
+    Ok(None)
 }


### PR DESCRIPTION
When running `nix profile install` on this branch, `cargo test` gets run with a release build, rather than a debug build, so the update to the test will work with either flow.