### PR TITLE
Windows compatibility

### DIFF
--- a/src/githook.rs
+++ b/src/githook.rs
@@ -2,7 +2,7 @@ use crate::cdcrate::change_directory_to_crate_root;
 use crate::executable::Executable;
 use crate::git;
 use anyhow_std::PathAnyhow;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 const CONTENTS: &str = include_str!("githook/pre-commit.sh");
 
@@ -39,6 +39,7 @@ pub fn install() -> anyhow::Result<()> {
     let p = get_path()?;
     println!("Installing: {:?}", p.display());
     p.write_anyhow(CONTENTS)?;
+    #[cfg(target_family = "unix")]
     make_executable(&p)?;
     Ok(())
 }
@@ -75,8 +76,8 @@ pub fn get_path() -> anyhow::Result<PathBuf> {
     git::get_hook_path("pre-commit")
 }
 
-// TODO: implement for other platforms:
-fn make_executable(p: &Path) -> anyhow::Result<()> {
+#[cfg(target_family = "unix")]
+fn make_executable(p: &std::path::Path) -> anyhow::Result<()> {
     use anyhow::Context;
     use std::os::unix::fs::PermissionsExt;
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -116,11 +116,13 @@ where
         .next()
         .ok_or_else(|| mk_err(MissingSubcommand, "nothing"))?;
 
-    let file_name = Path::new(arg.as_os_str())
+    let file_path = Path::new(arg.as_os_str());
+    let file_name = file_path
         .file_name()
         .ok_or_else(|| mk_err(InvalidSubcommand, &format!("{arg:?}")))?;
+    let extension = file_path.extension().unwrap_or_else(|| "".as_ref());
 
-    if file_name != "cargo-checkmate" {
+    if file_name != "cargo-checkmate" && extension != std::env::consts::EXE_EXTENSION {
         return Err(mk_err(InvalidSubcommand, &format!("{arg:?}")));
     }
 

--- a/src/run/tests.rs
+++ b/src/run/tests.rs
@@ -52,7 +52,9 @@ where
         } else if md.is_file() {
             use anyhow_std::OsStrAnyhow;
 
-            if childpath.file_name_anyhow()?.to_str_anyhow()? == env!("CARGO_PKG_NAME") {
+            if childpath.file_stem_anyhow()?.to_str_anyhow()? == env!("CARGO_PKG_NAME")
+                && childpath.extension_anyhow()? == std::env::consts::EXE_EXTENSION
+            {
                 return Ok(Some(childpath.canonicalize_anyhow()?));
             }
         }


### PR DESCRIPTION
fixes #34 

I'm developing on windows and have some cursory experience with git hooks. As far as I know they work just like they would on linux (they run via git-bash), except the files don't have to be executable, of course. I imagine things would get hairy if you use programs that git-bash doesn't provide, but `cargo-checkmate`'s hook is pretty barebones.

With that in mind, all I had to was remove `make_executable` from the windows build. I also fixed some runtime issues where the filename `cargo-checkmate` was expected, but it's `cargo-checkmate.exe` on windows. I'd appreciate a linux user giving the changes a quick test, just to make sure I didn't mess it up for you.

The tests are all green, and playing around with `cargo checkmate git-hook` showed no issues. This commit was verified with the hook!
```
❯ git commit -m "Windows compatibility"
cargo checkmate git-hook:

running 6 cargo-checkmate validations
cargo-checkmate run check  ... ok      in   0.301 seconds
cargo-checkmate run format ... ok      in   0.234 seconds
cargo-checkmate run clippy ... ok      in   0.370 seconds
cargo-checkmate run build  ... ok      in   0.297 seconds
cargo-checkmate run test   ... ok      in   0.422 seconds
cargo-checkmate run doc    ... ok      in   0.230 seconds

cargo-checkmate result: ok. 6 passed; 0 failed; total duration 1s 860ms
[main 78f150a5] Windows compatibility
 3 files changed, 11 insertions(+), 6 deletions(-)
```

If you can think of anything else I should test, let me know.